### PR TITLE
Docs update: Qubes 4.2 dom0 needs extra packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Open **Keyboard Settings** *(on Qubes OS GUI)*:
   * **`Ctrl`+`Print`**
     * `xfce4-screenshooter -r -o /opt/qubes-screenshooter/send-screenshot-to-chosen-vm`
 
+If you are running Qubes 4.2, additional packages are needed in `dom0`:
+```sh
+sudo qubes-dom0-upgrade xwininfo ImageMagick
+```
 
 ## Dependencies & Third-party tools
 


### PR DESCRIPTION
Small documentation update for Qubes 4.2 as its dom0 doesn't seem to ship with ImageMagick or xwininfo anymore.

Not having these packages installed will cause the script to silently fail-open (screenshot will be taken and sent to the target qube but not stripped as designed).